### PR TITLE
#9224 sfDoctrineCreateModelTablesTask should have an option to skip "build-model" task

### DIFF
--- a/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineCreateModelTablesTask.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineCreateModelTablesTask.class.php
@@ -29,6 +29,7 @@ class sfDoctrineCreateModelTables extends sfDoctrineBaseTask
     $this->addOptions(array(
       new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', 'frontend'),
       new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'dev'),
+      new sfCommandOption('no-build-model', null, sfCommandOption::PARAMETER_NONE, 'Skip the doctrine:build-model task.')
     ));
 
     $this->namespace = 'doctrine';
@@ -46,10 +47,12 @@ EOF;
   {
     $databaseManager = new sfDatabaseManager($this->configuration);
 
-    $buildModel = new sfDoctrineBuildModelTask($this->dispatcher, $this->formatter);
-    $buildModel->setCommandApplication($this->commandApplication);
-    $buildModel->setConfiguration($this->configuration);
-    $ret = $buildModel->run();
+    if (!$options['no-build-model']) {
+      $buildModel = new sfDoctrineBuildModelTask($this->dispatcher, $this->formatter);
+      $buildModel->setCommandApplication($this->commandApplication);
+      $buildModel->setConfiguration($this->configuration);
+      $ret = $buildModel->run();
+    }
 
     $connections = array();
     $models = $arguments['models'];


### PR DESCRIPTION
@see http://trac.symfony-project.org/ticket/9224
