### PR TITLE
Fix PHP 5.3 error

### DIFF
--- a/lib/vendor/creole/CreoleTypes.php
+++ b/lib/vendor/creole/CreoleTypes.php
@@ -36,7 +36,7 @@ abstract class CreoleTypes {
         const INTEGER = 5;
         const CHAR = 6;
         const VARCHAR = 7;
-        const TEXT = 17;
+        const TEXT = 30;
         const FLOAT = 8;
         const DOUBLE = 9;
         const DATE = 10;


### PR DESCRIPTION
Fixing the PHP 5.3 bug in Creole, needed to upgrade the software on extreme-legacy sites.

Without this change the models can no longer be generated.
