### PR TITLE
added .gitignore ignores list in sfFinder

### DIFF
--- a/lib/util/sfFinder.class.php
+++ b/lib/util/sfFinder.class.php
@@ -347,7 +347,7 @@ class sfFinder
 
     if ($this->ignore_version_control)
     {
-      $ignores = array('.svn', '_svn', 'CVS', '_darcs', '.arch-params', '.monotone', '.bzr', '.git', '.hg');
+      $ignores = array('.svn', '_svn', 'CVS', '_darcs', '.arch-params', '.monotone', '.bzr', '.git', '.gitignore', '.hg');
 
       $finder->discard($ignores)->prune($ignores);
     }

--- a/lib/util/sfFinder.class.php
+++ b/lib/util/sfFinder.class.php
@@ -347,7 +347,7 @@ class sfFinder
 
     if ($this->ignore_version_control)
     {
-      $ignores = array('.svn', '_svn', 'CVS', '_darcs', '.arch-params', '.monotone', '.bzr', '.git', '.gitignore', '.hg');
+      $ignores = array('.svn', '_svn', 'CVS', '_darcs', '.arch-params', '.monotone', '.bzr', '.git', '.gitignore', '.gitmodules', '.hg');
 
       $finder->discard($ignores)->prune($ignores);
     }


### PR DESCRIPTION
Added .gitignore to the list of ignores in sfFinder, primarily to stop my .gitignore from being deleted from the cache directory when I run symfony cc.
