### PR TITLE
Missing variables in sfWidgetFormDateRange->render

### DIFF
--- a/lib/widget/sfWidgetFormDateRange.class.php
+++ b/lib/widget/sfWidgetFormDateRange.class.php
@@ -58,8 +58,8 @@ class sfWidgetFormDateRange extends sfWidgetForm
     $value = array_merge(array('from' => '', 'to' => ''), is_array($value) ? $value : array());
 
     return strtr($this->translate($this->getOption('template')), array(
-      '%from_date%'      => $this->getOption('from_date')->render($name.'[from]', $value['from']),
-      '%to_date%'        => $this->getOption('to_date')->render($name.'[to]', $value['to']),
+      '%from_date%'      => $this->getOption('from_date')->render($name.'[from]', $value['from'], $attributes, $errors),
+      '%to_date%'        => $this->getOption('to_date')->render($name.'[to]', $value['to'], $attributes, $errors),
     ));
   }
 


### PR DESCRIPTION
Variables `$attributes` and `$errors` aren't provided to the `from_date` and `to_date` rendering.

All attributes given in the main widget are lost.
