### PR TITLE
Update regex for avoid ';' and dots just before @

### DIFF
--- a/lib/validator/sfValidatorEmail.class.php
+++ b/lib/validator/sfValidatorEmail.class.php
@@ -18,8 +18,8 @@
  */
 class sfValidatorEmail extends sfValidatorRegex
 {
-  const REGEX_EMAIL = '/^([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})$/i';
-
+  const REGEX_EMAIL = '/^[-a-z0-9~!$%^&*_=+}{\'?]+(\.[-a-z0-9~!$%^&*_=+}{\'?]+)*@([a-z0-9_][-a-z0-9_]*(\.[-a-z0-9_]+)*\.(aero|arpa|biz|com|coop|edu|gov|info|int|mil|museum|name|net|org|pro|travel|mobi|[a-z][a-z])|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}))(:[0-9]{1,5})?$/i '; // Arluison Guillaume's improvement of Warren Gaebel's email regex
+  
   /**
    * @see sfValidatorRegex
    */


### PR DESCRIPTION
The initial regex is not robust enough to prevent exceptions from RFC 2822 of switmailer.
