### PR TITLE
Usage of Closure as array

### DIFF
--- a/lib/autoload/sfAutoloadAgain.class.php
+++ b/lib/autoload/sfAutoloadAgain.class.php
@@ -69,7 +69,7 @@ class sfAutoloadAgain
     {
       foreach ($autoloads as $position => $autoload)
       {
-        if ($this === $autoload[0])
+        (is_array($autoload) && $this === $autoload[0])
         {
           break;
         }


### PR DESCRIPTION
"Cannot use object of type Closure as array"
If I try to do phpunit tests (PHPUnit Version 3.7.7) "spl_autoload_functions()"
returns no more an array but a Closure.
@see https://github.com/sebastianbergmann/phpunit/issues/684
