### PR TITLE
preg_replace /e modifier deprecated as of PHP5.4

### DIFF
--- a/lib/response/sfWebResponse.class.php
+++ b/lib/response/sfWebResponse.class.php
@@ -328,7 +328,19 @@ class sfWebResponse extends sfResponse
    */
   protected function normalizeHeaderName($name)
   {
-    return preg_replace('/\-(.)/e', "'-'.strtoupper('\\1')", strtr(ucfirst(strtolower($name)), '_', '-'));
+    return preg_replace_callback('/\-(.)/', array($this, 'normalizeHeaderCallback'), strtr(ucfirst(strtolower($name)), '_', '-'));
+  }
+  
+  /**
+   * Callback for the normalizeHeader function.
+   * 
+   * @param string[] $text a regular expression mtch
+   * 
+   * @return string the text in capital letters and leading dash
+   */
+  protected static function normalizeHeaderCallback( $text )
+  {
+    return '-'.strtoupper($text[0]);
   }
 
   /**


### PR DESCRIPTION
The /e modifier was deprecated in PHP5.4 and results in warnings. Use preg_replace_callback instead. Don't use anonymous function to preserve backwards compatibility.
