### PR TITLE
Fix: Deprecated: preg_replace(): The /e modifier..

### DIFF
--- a/lib/util/sfToolkit.class.php
+++ b/lib/util/sfToolkit.class.php
@@ -359,7 +359,22 @@ class sfToolkit
    */
   public static function pregtr($search, $replacePairs)
   {
-    return preg_replace(array_keys($replacePairs), array_values($replacePairs), $search);
+    foreach($replacePairs as $pattern => $replacement)
+    {
+      if (preg_match('/(.*)e$/', $pattern, $matches))
+      {
+        $pattern = $matches[1];
+        $search = preg_replace_callback($pattern, function ($matches) use ($replacement) {
+          preg_match("/('::'\.)?([a-z]*)\('\\\\([0-9]{1})'\)/", $replacement, $match);
+          return ($match[1]==''?'':'::').call_user_func($match[2], $matches[$match[3]]);
+        }, $search);
+      }
+      else
+      {
+        $search = preg_replace($pattern, $replacement, $search);
+      }
+    }
+    return $search;
   }
 
   /**


### PR DESCRIPTION
Fix for Deprecated: preg_replace(): The /e modifier warning on line 362
