### PR TITLE
patch for PHP 5.6

### DIFF
--- a/lib/command/sfCommandManager.class.php
+++ b/lib/command/sfCommandManager.class.php
@@ -108,7 +108,10 @@ class sfCommandManager
     else if (!is_array($arguments))
     {
       // hack to split arguments with spaces : --test="with some spaces"
-      $arguments = preg_replace('/(\'|")(.+?)\\1/e', "str_replace(' ', '=PLACEHOLDER=', '\\2')", $arguments);
+      $arguments = preg_replace_callback('/(\'|")(.+?)\\1/', function($matches) {
+        return str_replace(' ', '=PLACEHOLDER=', $matches[2]);
+      }, $arguments);
+
       $arguments = preg_split('/\s+/', $arguments);
       $arguments = str_replace('=PLACEHOLDER=', ' ', $arguments);
     }

--- a/lib/response/sfWebResponse.class.php
+++ b/lib/response/sfWebResponse.class.php
@@ -406,7 +406,13 @@ class sfWebResponse extends sfResponse
    */
   protected function normalizeHeaderName($name)
   {
-    return preg_replace('/\-(.)/e', "'-'.strtoupper('\\1')", strtr(ucfirst(strtolower($name)), '_', '-'));
+    return preg_replace_callback(
+      '/\-(.)/',
+      function ($matches) {
+        return '-'.strtoupper($matches[1]);
+      },
+      strtr(ucfirst(strtolower($name)), '_', '-')
+    );
   }
 
   /**


### PR DESCRIPTION
Fix errors:
PHP Deprecated: preg_replace(): The /e modifier is deprecated, use preg_replace_callback instead in ...lib/response/sfWebResponse.class.php on line 409
PHP Deprecated:  preg_replace(): The /e modifier is deprecated, use preg_replace_callback instead in ...lib/command/sfCommandManager.class.php on line 111